### PR TITLE
disable javadoc doclint and make other minor pom revisions

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.willisju.linkedinj</groupId>
     <artifactId>linkedin</artifactId>
-    <version>1.1</version>
+    <version>1.1.1</version>
   </parent>
   <artifactId>linkedin-j-core</artifactId>
   <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   
 	<groupId>com.willisju.linkedinj</groupId>
     <artifactId>linkedin</artifactId>
-    <version>1.1</version>
+    <version>1.1.1</version>
     <packaging>pom</packaging>
     <name>LinkedIn-J</name>
 	
@@ -13,6 +13,7 @@
 		<repoPath>https://github.com/willisju/linkedin-j/raw/master/mvn-repo/</repoPath>
 		<localRepoPath></localRepoPath>
 		<javaVersion>1.7</javaVersion>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 	
   <licenses>
@@ -82,6 +83,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.18.1</version>
           <configuration>
             <testFailureIgnore>true</testFailureIgnore>
           </configuration>
@@ -90,7 +92,11 @@
 		<plugin>
 			<groupId>org.apache.maven.plugins</groupId>
 			<artifactId>maven-javadoc-plugin</artifactId>
-			<executions>
+                        <version>2.10.1</version>
+			<configuration>
+                            <additionalparam>-Xdoclint:none</additionalparam>
+                        </configuration>
+                        <executions>
 				<execution>
 					<id>attach-javadocs</id>
 					<goals>
@@ -102,6 +108,7 @@
 		<plugin>
 		  <groupId>org.apache.maven.plugins</groupId>
 		  <artifactId>maven-source-plugin</artifactId>
+                  <version>2.4</version>
 		  <executions>
 			<execution>
 			  <id>attach-sources</id>


### PR DESCRIPTION
Set of changes includes the following:
- add -Xdoclint:none javadoc parameter
- set source encoding to utf-8
- declare source, javadoc, and surefire plugin versions
- raise version to 1.1.1
