### PR TITLE
Make tests requiring API key optional

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -3,10 +3,13 @@
   <parent>
     <groupId>com.willisju.linkedinj</groupId>
     <artifactId>linkedin</artifactId>
-    <version>1.1.2</version>
+    <version>1.1.3-SNAPSHOT</version>
   </parent>
   <artifactId>linkedin-j-core</artifactId>
   <packaging>jar</packaging>
+  <properties>
+      <com.google.code.linkedinapi.client.TestConstantsFile>${com.willisju.linkedinj:com.google.code.linkedinapi.client.TestConstantsFile}</com.google.code.linkedinapi.client.TestConstantsFile>
+  </properties>
   <build>
     <pluginManagement>
       <plugins>
@@ -14,9 +17,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <configuration>
-            <testFailureIgnore>true</testFailureIgnore>
-          </configuration>
+          <version>2.18.1</version>
         </plugin>
 	
 		
@@ -31,27 +32,4 @@
     </testResources>     
 	
   </build>
-  <dependencies>
-  	<dependency>
-  		<groupId>oauth.signpost</groupId>
-  		<artifactId>signpost-core</artifactId>
-  		<version>1.2.1.1</version>
-  	</dependency>
-    <dependency>
-      <groupId>commons-codec</groupId>
-      <artifactId>commons-codec</artifactId>
-      <version>1.3</version>
-    </dependency>
-	<dependency>
-	    <groupId>net.sf.kxml</groupId>
-	    <artifactId>kxml2</artifactId>
-	    <version>2.3.0</version>
-	</dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.5</version>
-      <scope>test</scope>
-    </dependency>
-  </dependencies>
 </project>

--- a/core/src/test/java/com/google/code/linkedinapi/client/AsyncLinkedInApiClientTest.java
+++ b/core/src/test/java/com/google/code/linkedinapi/client/AsyncLinkedInApiClientTest.java
@@ -31,6 +31,11 @@ import com.google.code.linkedinapi.schema.Network;
 import com.google.code.linkedinapi.schema.People;
 import com.google.code.linkedinapi.schema.Person;
 import com.google.code.linkedinapi.schema.UpdateComments;
+import org.junit.After;
+import static org.junit.Assert.*;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.BeforeClass;
 
 /**
  * @author Nabeel Mukhtar
@@ -38,10 +43,17 @@ import com.google.code.linkedinapi.schema.UpdateComments;
  */
 public class AsyncLinkedInApiClientTest extends LinkedInApiClientTest {
 	private AsyncLinkedInApiClient client;
-	
-	/** 
-	 * @see com.google.code.linkedinapi.client.LinkedInApiClientTest#setUp()
-	 */
+
+    @BeforeClass
+    public static void setUpClass() {
+        Assume.assumeTrue("LinkedIn API keys and other settings are required",
+                TestConstants.isOAuthTestsRunnable());
+    }
+
+    /**
+     * @see com.google.code.linkedinapi.client.LinkedInApiClientTest#setUp()
+     */
+    @Before
 	public void setUp() throws Exception {
 		super.setUp();
 		client = factory.createAsyncLinkedInApiClient(accessToken);
@@ -50,6 +62,7 @@ public class AsyncLinkedInApiClientTest extends LinkedInApiClientTest {
 	/**
 	 * @see com.google.code.linkedinapi.client.LinkedInApiClientTest#tearDown()
 	 */
+    @After
 	public void tearDown() throws Exception {
 		super.tearDown();
 		client = null;

--- a/core/src/test/java/com/google/code/linkedinapi/client/LinkedInApiClientTest.java
+++ b/core/src/test/java/com/google/code/linkedinapi/client/LinkedInApiClientTest.java
@@ -66,12 +66,14 @@ import com.google.code.linkedinapi.schema.Person;
 import com.google.code.linkedinapi.schema.Products;
 import com.google.code.linkedinapi.schema.UpdateComments;
 import com.google.code.linkedinapi.schema.VisibilityType;
+import static org.junit.Assert.*;
+import org.junit.Assume;
 
 /**
  * @author Nabeel Mukhtar
  *
  */
-public abstract class LinkedInApiClientTest extends TestCase {
+public abstract class LinkedInApiClientTest {
 
     /** Field description */
     protected LinkedInApiClientFactory factory;
@@ -89,7 +91,10 @@ public abstract class LinkedInApiClientTest extends TestCase {
      * @throws java.lang.Exception
      */
     @BeforeClass
-    public static void setUpBeforeClass() throws Exception {}
+    public static void setUpBeforeClass() throws Exception {
+        Assume.assumeTrue("LinkedIn API keys and other settings are required", 
+                TestConstants.isOAuthTestsRunnable());
+    }
 
     /**
      * @throws java.lang.Exception

--- a/core/src/test/java/com/google/code/linkedinapi/client/LinkedInApiJaxbClientTest.java
+++ b/core/src/test/java/com/google/code/linkedinapi/client/LinkedInApiJaxbClientTest.java
@@ -16,7 +16,10 @@
  */
 package com.google.code.linkedinapi.client;
 
+import com.google.code.linkedinapi.client.constant.TestConstants;
 import com.google.code.linkedinapi.client.impl.LinkedInApiJaxbClient;
+import org.junit.Assume;
+import org.junit.BeforeClass;
 
 /**
  * @author Nabeel Mukhtar
@@ -26,13 +29,15 @@ public class LinkedInApiJaxbClientTest extends LinkedInApiClientTest {
 	
 	/** 
 	 * @see com.google.code.linkedinapi.client.LinkedInApiClientTest#setUp()
-	 */
-	public void setUp() throws Exception {
-		super.setUp();
-		client = factory.createLinkedInApiClient(LinkedInApiJaxbClient.class, accessToken);
-	}
+     */
+    public void setUp() throws Exception {
+        Assume.assumeTrue("LinkedIn API keys and other settings are required",
+                TestConstants.isOAuthTestsRunnable());
+        super.setUp();
+        client = factory.createLinkedInApiClient(LinkedInApiJaxbClient.class, accessToken);
+    }
 
-	/**
+    /**
 	 * @see com.google.code.linkedinapi.client.LinkedInApiClientTest#tearDown()
 	 */
 	public void tearDown() throws Exception {

--- a/core/src/test/java/com/google/code/linkedinapi/client/LinkedInApiXppClientTest.java
+++ b/core/src/test/java/com/google/code/linkedinapi/client/LinkedInApiXppClientTest.java
@@ -16,7 +16,10 @@
  */
 package com.google.code.linkedinapi.client;
 
+import com.google.code.linkedinapi.client.constant.TestConstants;
 import com.google.code.linkedinapi.client.impl.LinkedInApiXppClient;
+import org.junit.Assume;
+import org.junit.BeforeClass;
 
 /**
  * @author Nabeel Mukhtar
@@ -24,8 +27,14 @@ import com.google.code.linkedinapi.client.impl.LinkedInApiXppClient;
  */
 public class LinkedInApiXppClientTest extends LinkedInApiClientTest {
 
-	/** 
-	 * @see com.google.code.linkedinapi.client.LinkedInApiClientTest#setUp()
+    @BeforeClass
+    public static void setUpClass() {
+        Assume.assumeTrue("LinkedIn API keys and other settings are required",
+                TestConstants.isOAuthTestsRunnable());
+    }
+
+    /**
+     * @see com.google.code.linkedinapi.client.LinkedInApiClientTest#setUp()
 	 */
 	public void setUp() throws Exception {
 		super.setUp();

--- a/core/src/test/java/com/google/code/linkedinapi/client/constant/TestConstants.java
+++ b/core/src/test/java/com/google/code/linkedinapi/client/constant/TestConstants.java
@@ -15,7 +15,9 @@
  * 
  */
 package com.google.code.linkedinapi.client.constant;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Properties;
 
 /**
@@ -24,18 +26,50 @@ import java.util.Properties;
  */
 public final class TestConstants {
 
+    public static final String PROP_TEST_CONSTANTS_FILE = "com.google.code.linkedinapi.client.TestConstantsFile";
+    
     /** Field description */
-    public static final String TEST_CONSTANTS_FILE = "TestConstants.properties";
+    private static final String TEST_CONSTANTS_FILE;
 
     /** Field description */
     private static final Properties testConstants = new Properties();
 
+    private static final boolean oauthTestsRunnable;
+
     static {
-        try {
-            testConstants.load(TestConstants.class.getResourceAsStream(TEST_CONSTANTS_FILE));
-        } catch (IOException e) {
-            e.printStackTrace();
+        boolean oauthTestsRunnable_ = false;
+        TEST_CONSTANTS_FILE = System.getProperty(PROP_TEST_CONSTANTS_FILE);
+        if (TEST_CONSTANTS_FILE == null) {
+            System.err.println("To run the OAuth tests, create a properties "
+                    + "file with the entries as specified in this class and"
+                    + "set the value of system property "
+                    + "'com.google.code.linkedinapi.client.TestConstantsFile' "
+                    + "to the file pathname. If the value of POM property "
+                    + "'com.willisju.linkedinj:com.google.code.linkedinapi.client.TestConstantsFile' "
+                    + "is present in your Maven user settings, it will propagate.");
+        } else {
+            InputStream in = null;
+            try {
+                in = new FileInputStream(TEST_CONSTANTS_FILE);
+                testConstants.load(in);
+                oauthTestsRunnable_ = true;
+            } catch (IOException e) {
+                e.printStackTrace(System.err);
+            } finally {
+                if (in != null) {
+                    try {
+                        in.close();
+                    } catch (IOException e2) {
+                        System.err.println("failed to close file " + TEST_CONSTANTS_FILE + ": " + e2);
+                    }
+                }
+            }
         }
+        oauthTestsRunnable = oauthTestsRunnable_;
+    }
+    
+    public static boolean isOAuthTestsRunnable() {
+        return oauthTestsRunnable;
     }
     
     /** Field description */

--- a/core/src/test/java/com/google/code/linkedinapi/client/oauth/LinkedInOAuthServiceTest.java
+++ b/core/src/test/java/com/google/code/linkedinapi/client/oauth/LinkedInOAuthServiceTest.java
@@ -31,8 +31,6 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import junit.framework.TestCase;
-
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -41,12 +39,14 @@ import org.junit.Test;
 
 import com.google.code.linkedinapi.client.constant.ApplicationConstants;
 import com.google.code.linkedinapi.client.constant.TestConstants;
+import static org.junit.Assert.*;
+import org.junit.Assume;
 
 /**
  * @author nmukhtar
  *
  */
-public class LinkedInOAuthServiceTest extends TestCase {
+public final class LinkedInOAuthServiceTest {
 	
     /** Field description */
     protected LinkedInOAuthService service;
@@ -80,11 +80,15 @@ public class LinkedInOAuthServiceTest extends TestCase {
 	 */
 	@Before
 	public void setUp() throws Exception {
-		assertNotNullOrEmpty(String.format(RESOURCE_MISSING_MESSAGE, "Consumer Key"), TestConstants.LINKED_IN_TEST_CONSUMER_KEY);
-		assertNotNullOrEmpty(String.format(RESOURCE_MISSING_MESSAGE, "Consumer Secret"), TestConstants.LINKED_IN_TEST_CONSUMER_SECRET);
-		LinkedInOAuthServiceFactory factory = LinkedInOAuthServiceFactory.getInstance();
-		service = factory.createLinkedInOAuthService(TestConstants.LINKED_IN_TEST_CONSUMER_KEY,
-                TestConstants.LINKED_IN_TEST_CONSUMER_SECRET);
+        Assume.assumeTrue("LinkedIn API keys and other settings are required", 
+                TestConstants.isOAuthTestsRunnable());
+        if (TestConstants.isOAuthTestsRunnable()) {
+            assertNotNullOrEmpty(String.format(RESOURCE_MISSING_MESSAGE, "Consumer Key"), TestConstants.LINKED_IN_TEST_CONSUMER_KEY);
+            assertNotNullOrEmpty(String.format(RESOURCE_MISSING_MESSAGE, "Consumer Secret"), TestConstants.LINKED_IN_TEST_CONSUMER_SECRET);
+            LinkedInOAuthServiceFactory factory = LinkedInOAuthServiceFactory.getInstance();
+            service = factory.createLinkedInOAuthService(TestConstants.LINKED_IN_TEST_CONSUMER_KEY,
+                    TestConstants.LINKED_IN_TEST_CONSUMER_SECRET);
+        }
 	}
 
 	/**

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   
 	<groupId>com.willisju.linkedinj</groupId>
     <artifactId>linkedin</artifactId>
-    <version>1.1.2</version>
+    <version>1.1.3</version>
     <packaging>pom</packaging>
     <name>LinkedIn-J</name>
 	
@@ -64,6 +64,11 @@
 	  <name>WJU</name>
       <id>willisju</id>
     </developer>
+    <developer>
+        <name>Mike Chaberski</name>
+        <id>mike10004</id>
+    </developer>
+    
   </developers>
   <modules>
     <module>core</module>
@@ -74,7 +79,7 @@
 		<plugin>
 			<groupId>org.apache.maven.plugins</groupId>
 			<artifactId>maven-compiler-plugin</artifactId>
-			<version>2.3.2</version>
+			<version>2.5.1</version>
 			<configuration>
 				<source>${javaVersion}</source>
 				<target>${javaVersion}</target>
@@ -82,7 +87,7 @@
 		</plugin>
 		<plugin>
 			<artifactId>maven-release-plugin</artifactId>
-			<version>2.4.1</version>
+			<version>2.5.1</version>
 			<configuration>
 				<useReleaseProfile>false</useReleaseProfile>
 				<releaseProfiles>release</releaseProfiles>
@@ -95,9 +100,6 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.18.1</version>
-          <configuration>
-            <testFailureIgnore>true</testFailureIgnore>
-          </configuration>
         </plugin>
 	
 		<plugin>
@@ -172,7 +174,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.5</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
 	<dependency>


### PR DESCRIPTION
Makes the unit tests that require API key (and other configuration data) optional.
